### PR TITLE
feature(command,args): use helper functions

### DIFF
--- a/docs/reference/values.md
+++ b/docs/reference/values.md
@@ -67,9 +67,9 @@ Kubernetes: `>=1.20.0-0`
 | [:fontawesome-solid-book:  configMaps](../start/values/configmaps.md) | list | `[]` | Define a list of extra ConfigMap objects. See values.yaml or chart documentation for examples on syntax |
 | [:fontawesome-solid-book:  configMapsHash](../start/values/configmapshash.md) | bool | `false` | Redeploy Deployments and Statefulsets if deployed ConfigMaps content change. |
 | [:fontawesome-solid-book:  cronjobspec](../start/values/cronjobspec.md) | object | see subvalues | Cronjobspec settings |
-| :fontawesome-solid-arrow-turn-up:{ .rotate-90 } cronjobspec.args | list | `[]` | Define args for cronjob |
+| :fontawesome-solid-arrow-turn-up:{ .rotate-90 } cronjobspec.args | list | `[]` | Define args for cronjob  Starting from Kubedeploy version 1.2 you should start using `image.args` instead of `cronjobspec.args`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed. |
 | :fontawesome-solid-arrow-turn-up:{ .rotate-90 } cronjobspec.backoffLimit | int | `3` | Define job backoff limit, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) |
-| :fontawesome-solid-arrow-turn-up:{ .rotate-90 } cronjobspec.command | list | `[]` | Define command for cronjob |
+| :fontawesome-solid-arrow-turn-up:{ .rotate-90 } cronjobspec.command | list | `[]` | Define command for cronjob  Starting from Kubedeploy version 1.2 you should start using `image.command` instead of `cronjobspec.command`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed. |
 | :fontawesome-solid-arrow-turn-up:{ .rotate-90 } cronjobspec.concurrencyPolicy | string | `""` | Define concurrency policy options: Allow (default), Forbid or Replace, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy) |
 | :fontawesome-solid-arrow-turn-up:{ .rotate-90 } cronjobspec.failedJobsHistoryLimit | int | `1` | Define number of failed Job logs to keep |
 | :fontawesome-solid-arrow-turn-up:{ .rotate-90 } cronjobspec.schedule | string | `"0 * * * *"` | Define cronjob schedule, for details see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) |
@@ -120,9 +120,9 @@ Kubernetes: `>=1.20.0-0`
 | :fontawesome-solid-arrow-turn-up:{ .rotate-90 } initContainers.pullPolicy | optional | `"IfNotPresent"` | initContainers image pull policy |
 | :fontawesome-solid-arrow-turn-up:{ .rotate-90 } initContainers.resources | optional | `{}` | Define initContainers global resource requests and limits. Will be applied to all initContainers if more specific (per container) resource requests and limits are not defined |
 | [:fontawesome-solid-book:  jobspec](../start/values/jobspec.md) | object | see subvalues | jobspec settings |
-| :fontawesome-solid-arrow-turn-up:{ .rotate-90 } jobspec.args | list | `[]` | Define args for Job |
+| :fontawesome-solid-arrow-turn-up:{ .rotate-90 } jobspec.args | list | `[]` | Define args for Job  Starting from Kubedeploy version 1.2 you should start using `image.args` instead of `jobspec.args`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed. |
 | :fontawesome-solid-arrow-turn-up:{ .rotate-90 } jobspec.backoffLimit | int | `3` | Define Job backoff limit, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) |
-| :fontawesome-solid-arrow-turn-up:{ .rotate-90 } jobspec.command | list | `[]` | Define command for Job |
+| :fontawesome-solid-arrow-turn-up:{ .rotate-90 } jobspec.command | list | `[]` | Define command for Job  Starting from Kubedeploy version 1.2 you should start using `image.command` instead of `jobspec.command`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed. |
 | :fontawesome-solid-arrow-turn-up:{ .rotate-90 } jobspec.parallelism | int | `1` | Define Job paralelisam, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism) |
 | :fontawesome-solid-arrow-turn-up:{ .rotate-90 } jobspec.restartPolicy | string | `"OnFailure"` | Define restart policy for jobs if deploymentMode=**Job**, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures) |
 | [:fontawesome-solid-book:  keda](../start/values/keda.md) | object | see subvalues | Keda settings |

--- a/docs/start/values/cronjobspec.md
+++ b/docs/start/values/cronjobspec.md
@@ -33,6 +33,11 @@ cronjobspec:
 9. Define concurrency policy options: Allow (default), Forbid or Replace, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy)
 
 
+!!! danger "Deprecation Warning"
+
+    Starting from Kubedeploy version 1.2, you should begin using image.command and image.args instead of cronjobspec.command and cronjobspec.args. These values will remain available as failsafe options until Kubedeploy 2.0, at which point they will be removed.
+
+
 !!! example "Define cronjob"
 
     ```yaml title="values.yaml" linenums="1" hl_lines="7-9"

--- a/docs/start/values/jobspec.md
+++ b/docs/start/values/jobspec.md
@@ -24,6 +24,9 @@ jobspec:
 4. Define Job paralelisam, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism)
 5. Define Job backoff limit, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy)
 
+!!! danger "Deprecation Warning"
+
+    Starting from Kubedeploy version 1.2, you should begin using image.command and image.args instead of cronjobspec.command and cronjobspec.args. These values will remain available as failsafe options until Kubedeploy 2.0, at which point they will be removed.
 
 !!! example "Define job"
 

--- a/kubedeploy/README.md
+++ b/kubedeploy/README.md
@@ -58,9 +58,9 @@ Kubernetes: `>=1.20.0-0`
 | configMaps | list | `[]` | Define a list of extra ConfigMap objects. See values.yaml or chart documentation for examples on syntax |
 | configMapsHash | bool | `false` | Redeploy Deployments and Statefulsets if deployed ConfigMaps content change. |
 | cronjobspec | object | see subvalues | Cronjobspec settings |
-| cronjobspec.args | list | `[]` | Define args for cronjob |
+| cronjobspec.args | list | `[]` | Define args for cronjob  Starting from Kubedeploy version 1.2 you should start using `image.args` instead of `cronjobspec.args`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed. |
 | cronjobspec.backoffLimit | int | `3` | Define job backoff limit, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) |
-| cronjobspec.command | list | `[]` | Define command for cronjob |
+| cronjobspec.command | list | `[]` | Define command for cronjob  Starting from Kubedeploy version 1.2 you should start using `image.command` instead of `cronjobspec.command`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed. |
 | cronjobspec.concurrencyPolicy | string | `""` | Define concurrency policy options: Allow (default), Forbid or Replace, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy) |
 | cronjobspec.failedJobsHistoryLimit | int | `1` | Define number of failed Job logs to keep |
 | cronjobspec.schedule | string | `"0 * * * *"` | Define cronjob schedule, for details see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec) |
@@ -111,9 +111,9 @@ Kubernetes: `>=1.20.0-0`
 | initContainers.pullPolicy | optional | `"IfNotPresent"` | initContainers image pull policy |
 | initContainers.resources | optional | `{}` | Define initContainers global resource requests and limits. Will be applied to all initContainers if more specific (per container) resource requests and limits are not defined |
 | jobspec | object | see subvalues | jobspec settings |
-| jobspec.args | list | `[]` | Define args for Job |
+| jobspec.args | list | `[]` | Define args for Job  Starting from Kubedeploy version 1.2 you should start using `image.args` instead of `jobspec.args`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed. |
 | jobspec.backoffLimit | int | `3` | Define Job backoff limit, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) |
-| jobspec.command | list | `[]` | Define command for Job |
+| jobspec.command | list | `[]` | Define command for Job  Starting from Kubedeploy version 1.2 you should start using `image.command` instead of `jobspec.command`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed. |
 | jobspec.parallelism | int | `1` | Define Job paralelisam, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism) |
 | jobspec.restartPolicy | string | `"OnFailure"` | Define restart policy for jobs if deploymentMode=**Job**, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures) |
 | keda | object | see subvalues | Keda settings |

--- a/kubedeploy/templates/NOTES.txt
+++ b/kubedeploy/templates/NOTES.txt
@@ -1,4 +1,3 @@
-
 {{- if .Values.ingress.enabled }}
 Application will be available on these URLs:
 
@@ -30,7 +29,30 @@ Get the application URL by running these commands:
 
 {{- if $.Values.service.enabled }}
 {{- if and (not $.Values.service.ports) (not $.Values.ports) }}
-
 DEPRECATION WARNING: Service is enabled but no container or service ports are defined. This setup will stop working in kubedeploy 2.x
 {{- end }}
+{{- end }}
+
+{{ if and
+        (eq (toString $.Values.deploymentMode) "Cronjob")
+        $.Values.cronjobspec.command
+-}}
+DEPRECATION WARNING: Cronjob deployment mode using cronjobpsec.command will stop working in Kubedeploy 2.x. Please use image.command instead
+{{ else if and
+            (eq (toString $.Values.deploymentMode) "Job")
+            $.Values.jobspec.command
+-}}
+DEPRECATION WARNING: Job deployment mode using jobpsec.command will stop working in Kubedeploy 2.x. Please use image.command instead
+{{- end }}
+
+{{ if and
+        (eq (toString $.Values.deploymentMode) "Cronjob")
+        $.Values.cronjobspec.args
+-}}
+DEPRECATION WARNING: Cronjob deployment mode using cronjobpsec.args will stop working in Kubedeploy 2.x. Please use image.args instead
+{{ else if and
+            (eq (toString $.Values.deploymentMode) "Job")
+            $.Values.jobspec.args
+-}}
+DEPRECATION WARNING: Job deployment mode using jobpsec.args will stop working in Kubedeploy 2.x. Please use image.args instead
 {{- end }}

--- a/kubedeploy/templates/helpers/_common.spec.tpl
+++ b/kubedeploy/templates/helpers/_common.spec.tpl
@@ -27,14 +27,8 @@ spec:
     {{- range .Values.initContainers.containers }}
     - name: {{ required "Please define valid init container name" .name }}
       image: "{{ required "Please define valid init container repository" .repository }}:{{ .tag | default "latest" }}"
-      {{- with .command }}
-      command:
-        {{- toYaml . |nindent 8 }}
-      {{- end }}
-      {{- with .args }}
-      args:
-        {{- toYaml . |nindent 8 }}
-      {{- end }}
+      {{- include "kubedeploy.common.command" (list $ .) | indent 6 }}
+      {{- include "kubedeploy.common.args" (list $ .) | indent 6 }}
       {{- with $.Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -63,38 +57,8 @@ spec:
       {{- end }}
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
       imagePullPolicy: {{ .Values.image.pullPolicy |default "IfNotPresent" }}
-      {{- if eq (toString .Values.deploymentMode) "Job" }}
-      {{- with .Values.jobspec.command }}
-      command:
-      {{- toYaml . |nindent 8 }}
-      {{- end }}
-      {{- else if eq (toString .Values.deploymentMode) "Cronjob"}}
-      {{- with .Values.cronjobspec.command }}
-      command:
-      {{- toYaml . |nindent 8 }}
-      {{- end }}
-      {{- else }}
-      {{- with .Values.image.command }}
-      command:
-      {{- toYaml . |nindent 8 }}
-      {{- end }}
-      {{- end }}
-      {{- if eq (toString .Values.deploymentMode) "Job" }}
-      {{- with .Values.jobspec.args}}
-      args:
-      {{- toYaml . |nindent 8 }}
-      {{- end }}
-      {{- else if eq (toString .Values.deploymentMode) "Cronjob"}}
-      {{- with .Values.cronjobspec.args }}
-      args:
-      {{- toYaml . |nindent 8 }}
-      {{- end }}
-      {{- else }}
-      {{- with .Values.image.args }}
-      args:
-      {{- toYaml . |nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "kubedeploy.common.command" (list $ .Values) | indent 6 }}
+      {{- include "kubedeploy.common.args" (list $ .Values) | indent 6 }}
       {{- include "kubedeploy.common.env" . | indent 6 }}
       {{- include "kubedeploy.common.envFrom" . | indent 6 }}
       {{- with .Values.ports }}
@@ -130,14 +94,8 @@ spec:
     {{- range .Values.additionalContainers.containers }}
     - name: {{ required "Please define valid additional container name" .name }}
       image: "{{ required "Please define valid additional container repository" .repository }}:{{ .tag | default "latest" }}"
-      {{- with .command }}
-      command:
-        {{- toYaml . |nindent 8 }}
-      {{- end }}
-      {{- with .args }}
-      args:
-        {{- toYaml . |nindent 8 }}
-      {{- end }}
+      {{- include "kubedeploy.common.command" (list $ .) | indent 6 }}
+      {{- include "kubedeploy.common.args" (list $ .) | indent 6 }}
       {{- with $.Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/kubedeploy/templates/helpers/_common.tpl
+++ b/kubedeploy/templates/helpers/_common.tpl
@@ -21,3 +21,69 @@ securityContext:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end -}}
+
+{{/* Define command for common.spec */}}
+{{- define "kubedeploy.common.command" -}}
+{{- $top := index . 0 -}}
+{{- $command := index . 1 -}}
+{{- if hasKey $command "image" -}}
+{{/* TODO: 2.x Deprecation start */}}
+{{- if and
+            (eq (toString $top.Values.deploymentMode) "Cronjob")
+            $top.Values.cronjobspec.command
+}}
+command:
+  {{- toYaml $top.Values.cronjobspec.command | nindent 2 }}
+{{- else if and
+                (eq (toString $top.Values.deploymentMode) "Job")
+                $top.Values.jobspec.command
+}}
+command:
+  {{- toYaml $top.Values.jobspec.command | nindent 2 }}
+{{/* Deprecation end */}}
+{{- else -}}
+{{- with $command.image.command }}
+command:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+{{- else -}}
+{{- with $command.command }}
+command:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/* Define args for common.spec */}}
+{{- define "kubedeploy.common.args" -}}
+{{- $top := index . 0 -}}
+{{- $args := index . 1 -}}
+{{- if hasKey $args "image" -}}
+{{/* TODO: 2.x Deprecation start */}}
+{{- if and
+            (eq (toString $top.Values.deploymentMode) "Cronjob")
+            $top.Values.cronjobspec.args
+}}
+args:
+  {{- toYaml $top.Values.cronjobspec.args | nindent 2 }}
+{{- else if and
+                (eq (toString $top.Values.deploymentMode) "Job")
+                $top.Values.jobspec.args
+}}
+args:
+  {{- toYaml $top.Values.jobspec.args | nindent 2 }}
+{{/* Deprecation end */}}
+{{- else -}}
+{{- with $args.image.args }}
+args:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+{{- else -}}
+{{- with $args.args }}
+args:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/kubedeploy/tests/cronjobspec_test.yaml
+++ b/kubedeploy/tests/cronjobspec_test.yaml
@@ -44,6 +44,59 @@ tests:
         successfulJobsHistoryLimit: 1
         failedJobsHistoryLimit: 3
         concurrencyPolicy: "Forbid"
+      # TODO: remove in version 2.x
+      # testing backwards compatibility with image.command and args
+      image:
+        command: ['not-here']
+        args: ['-not-here']
+
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.schedule
+          value: "*/5 * * * *"
+      - equal:
+          path: spec.startingDeadlineSeconds
+          value: 60
+      - equal:
+          path: spec.successfulJobsHistoryLimit
+          value: 1
+      - equal:
+          path: spec.failedJobsHistoryLimit
+          value: 3
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.jobTemplate.spec.backoffLimit
+          value: 2
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command[0]
+          value: nginx
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          value: -v
+
+  - it: test custom cronjobspec with image commands and args
+    set:
+      deploymentMode: Cronjob
+      cronjobspec:
+        schedule: "*/5 * * * *"
+        restartPolicy: Never
+        backoffLimit: 2
+        startingDeadlineSeconds: 60
+        successfulJobsHistoryLimit: 1
+        failedJobsHistoryLimit: 3
+        concurrencyPolicy: "Forbid"
+      image:
+        command: ["nginx"]
+        args: ["-v"]
 
     asserts:
       - hasDocuments:

--- a/kubedeploy/tests/jobspec_test.yaml
+++ b/kubedeploy/tests/jobspec_test.yaml
@@ -31,6 +31,45 @@ tests:
         args: ["-v"]
         backoffLimit: 2
         parallelism: 2
+      # TODO: remove in version 2.x
+      # testing backwards compatibility with image.command and args
+      image:
+        command: ['not-here']
+        args: ['-not-here']
+
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.backoffLimit
+          value: 2
+      - equal:
+          path: spec.parallelism
+          value: 2
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: nginx
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: -v
+
+  - it: test custom jobspec with image commands and args
+    set:
+      deploymentMode: Job
+      jobspec:
+        restartPolicy: Never
+        command: ["nginx"]
+        args: ["-v"]
+        backoffLimit: 2
+        parallelism: 2
+      image:
+        command: ["nginx"]
+        args: ["-v"]
 
     asserts:
       - hasDocuments:

--- a/kubedeploy/values.yaml
+++ b/kubedeploy/values.yaml
@@ -564,8 +564,10 @@ cronjobspec:
   # Define restart policy for cronjob if deploymentMode=**Cronjob**.
   restartPolicy: OnFailure
   # -- Define command for cronjob
+  #  Starting from Kubedeploy version 1.2 you should start using `image.command` instead of `cronjobspec.command`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed.
   command: []
   # -- Define args for cronjob
+  #  Starting from Kubedeploy version 1.2 you should start using `image.args` instead of `cronjobspec.args`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed.
   args: []
   # -- Define job backoff limit, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy)
   backoffLimit: 3
@@ -585,8 +587,10 @@ jobspec:
   # -- Define restart policy for jobs if deploymentMode=**Job**, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures)
   restartPolicy: OnFailure
   # -- Define command for Job
+  #  Starting from Kubedeploy version 1.2 you should start using `image.command` instead of `jobspec.command`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed.
   command: []
   # -- Define args for Job
+  #  Starting from Kubedeploy version 1.2 you should start using `image.args` instead of `jobspec.args`. Values will be available as failsafe up to Kubedeploy 2.0 when they will be removed.
   args: []
   # -- Define Job paralelisam, see [reference](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism)
   parallelism: 1


### PR DESCRIPTION
Use common helper functions to define commands and args across containers. Added fallback to image.command and image.args for Job and CronJob deploymentModes with deprecation notice.

fix: #14