### PR TITLE
fix(keda): Don't render Keda template in absence of CRDs 

### DIFF
--- a/kubedeploy/.helmignore
+++ b/kubedeploy/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# tests
+tests

--- a/kubedeploy/templates/NOTES.txt
+++ b/kubedeploy/templates/NOTES.txt
@@ -26,6 +26,10 @@ Get the application URL by running these commands:
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
 
+{{- if and (not (.Capabilities.APIVersions.Has "keda.sh/v1alpha1")) .Values.keda.enabled -}}
+WARNING: Keda scaling is enabled but cluster has no support for it. Ensure Keda is installed in the cluster.
+{{- end -}}
+
 
 {{- if $.Values.service.enabled }}
 {{- if and (not $.Values.service.ports) (not $.Values.ports) }}

--- a/kubedeploy/templates/keda.yaml
+++ b/kubedeploy/templates/keda.yaml
@@ -1,4 +1,5 @@
 {{- if and (eq .Values.deploymentMode "Deployment") .Values.keda.enabled }}
+{{- if .Capabilities.APIVersions.Has "keda.sh/v1alpha1" -}}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -28,6 +29,7 @@ spec:
       behavior:
 {{- with .Values.keda.behavior }}
 {{- toYaml . | nindent 8 -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/kubedeploy/tests/keda_test.yaml
+++ b/kubedeploy/tests/keda_test.yaml
@@ -9,7 +9,6 @@ capabilities:
   minorVersion: 22
   apiVersions:
     - autoscaling/v2
-    - keda.sh/v1alpha1
 
 tests:
   - it: test if keda is disabled by default
@@ -17,6 +16,16 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: test if keda is disabled in absence of CRD
+    template: keda.yaml
+    set:
+      keda:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: test if hpa is disabled when keda is enabled
     template: hpa.yaml
     set:
@@ -36,6 +45,9 @@ tests:
           path: spec.replicas
 
   - it: test if keda is enabled with defaults
+    capabilities:
+      apiVersions:
+        - keda.sh/v1alpha1
     template: keda.yaml
     set:
       keda:
@@ -65,6 +77,9 @@ tests:
           value: false
 
   - it: test if keda is enabled with custom values
+    capabilities:
+      apiVersions:
+        - keda.sh/v1alpha1
     template: keda.yaml
     set:
       keda:


### PR DESCRIPTION
If Keda support is not found in the cluster, don't render Keda templates.
Instead print out a warning to user via NOTES.txt.