### PR TITLE
feat: add support for `subPath` field in configmaps

### DIFF
--- a/deploy-tests/cronjob.yaml
+++ b/deploy-tests/cronjob.yaml
@@ -56,6 +56,13 @@ releases:
             kubedeploy: |+
               configmap values
         - name: kubedeploy2-configmap
+          mount: true
+          mountPath: /data/confmap/kubedeploy2
+          subPath: kubedeploy2
+          data:
+            kubedeploy2: |+
+              configmap values
+        - name: kubedeploy3-configmap
           data:
             config: |+
-              config2
+              config3

--- a/deploy-tests/deployment.yaml
+++ b/deploy-tests/deployment.yaml
@@ -137,9 +137,16 @@ releases:
             kubedeploy: |+
               configmap values
         - name: kubedeploy2-configmap
+          mount: true
+          mountPath: /data/confmap/kubedeploy2
+          subPath: kubedeploy2
+          data:
+            kubedeploy2: |+
+              configmap values
+        - name: kubedeploy3-configmap
           data:
             config: |+
-              config2
+              config3
 
   # deployment with envFrom configmaps and additional containers
   - name: {{requiredEnv "RELEASE_NAME"}}-envfrom

--- a/deploy-tests/job.yaml
+++ b/deploy-tests/job.yaml
@@ -55,6 +55,13 @@ releases:
             kubedeploy: |+
               configmap values
         - name: kubedeploy2-configmap
+          mount: true
+          mountPath: /data/confmap/kubedeploy2
+          subPath: kubedeploy2
+          data:
+            kubedeploy2: |+
+              configmap values
+        - name: kubedeploy3-configmap
           data:
             config: |+
-              config2
+              config3

--- a/deploy-tests/lint-test.yaml
+++ b/deploy-tests/lint-test.yaml
@@ -16,16 +16,22 @@ releases:
       - configMapHash: true
       - configMaps:
         - name: kubedeploy-configmap
-          mount: True
+          mount: true
           mountPath: /data/confmap
           data:
             kubedeploy: |+
               configmap values
         - name: kubedeploy2-configmap
-          mount: False
+          mount: true
+          mountPath: /data/confmap/kubedeploy2
+          subPath: kubedeploy2
+          data:
+            kubedeploy2: |+
+              configmap values
+        - name: kubedeploy3-configmap
           data:
             config: |+
-              config2
+              config3
         - name: envfrom-configmap
           mount: False
           data:

--- a/deploy-tests/statefulset.yaml
+++ b/deploy-tests/statefulset.yaml
@@ -68,9 +68,16 @@ releases:
             kubedeploy: |+
               configmap values
         - name: kubedeploy2-configmap
+          mount: true
+          mountPath: /data/confmap/kubedeploy2
+          subPath: kubedeploy2
+          data:
+            kubedeploy2: |+
+              configmap values
+        - name: kubedeploy3-configmap
           data:
             config: |+
-              config2
+              config3
   # statefulset with extraSecrets and additional containers
   - name: {{requiredEnv "RELEASE_NAME"}}-extrasecrets
     labels:

--- a/docs/start/values/configmaps.md
+++ b/docs/start/values/configmaps.md
@@ -30,24 +30,35 @@ It is also possible to automatically mount ConfigMaps in all containers of a Pod
           kubedeploy.txt: |+
             configmap values
 
-      - name: configmap2
+      - name: configmap1
+        mount: True
+        mountPath: /data/confmap/kubedeploy2.txt # (required if mount=True) Define single-file mount path for this configmap
+        subPath: kubedeploy2.txt # (required if mountPath is a file path) Define which configmap data key to use to mount a single file
+        data:
+          kubedeploy2.txt: |+
+            configmap values
+
+      - name: configmap3
         data:
           config: |+
-            config2
+            config3
     ```
 
     ```bash title="Deploy command"
     helm install webapp sysbee/kubedeploy -f values.yaml
     ```
 
-As a result of the above example, Kubdeploy will create two extra ConfigMap objects named:
-`webapp-my-app-configmap1` and `webapp-my-app-configmap2`.
+As a result of the above example, Kubdeploy will create three extra ConfigMap objects named:
+`webapp-my-app-configmap1`, `webapp-my-app-configmap2` and `webapp-my-app-configmap3`.
 
 First configmap will also be mounted inside all of the Pod's containers at `/data/configmap` path exposing `kubedeploy.txt` as file on `/data/configmap/kubedeploy.txt`.
+Similarly, second configmap will be mounted inside all of the Pod's containers at `/data/configmap/kubedeploy2.txt` path. However, only `kubedeploy2.txt` file will be mounted, while existing directory contents will be preserved.
 
 !!! tip
 
     Common usecase in the above scenario would be creating and automatically mounting any configuration files your application might need during its runtime.
+
+    `subPath` is useful when a single file needs to be modified. For example, a default configuration file might reside inside a directory which contains multiple files and subdirectories. If the configmap is defined without a single-file `mountPath` and `subPath` fields, the entire directory will be cleared before mounting, which is undesirable.
 
 See also:
 

--- a/kubedeploy/templates/helpers/_volumes.tpl
+++ b/kubedeploy/templates/helpers/_volumes.tpl
@@ -38,6 +38,9 @@ volumeMounts:
 {{- $name := include "kubedeploy.cfgmapname" (list $ .) -}}
 {{- if eq (toString .mount | lower) "true" }}
   - mountPath: {{ required "You need to define .Values.configMaps[].mountPath if .Values.configMaps[].mount is set to True" .mountPath }}
+    {{- if .subPath }}
+    subPath: {{ .subPath }}
+    {{- end }}
     name: {{ $name }}
 {{- end }}
 {{- end }}

--- a/kubedeploy/tests/additionalContainers_test.yaml
+++ b/kubedeploy/tests/additionalContainers_test.yaml
@@ -70,18 +70,24 @@ tests:
            name: "value"
       securityContext:
         fsGroup: 2000
-      configMaps:
+      - configMaps:
         - name: kubedeploy-configmap
-          mount: True
+          mount: true
           mountPath: /data/confmap
           data:
             kubedeploy: |+
               configmap values
         - name: kubedeploy2-configmap
-          mount: False
+          mount: true
+          mountPath: /data/confmap/kubedeploy2
+          subPath: kubedeploy2
+          data:
+            kubedeploy2: |+
+              configmap values
+        - name: kubedeploy3-configmap
           data:
             config: |+
-              config2
+              config3
     asserts:
       - isSubset:
           path: spec.template.spec.containers[1].securityContext
@@ -102,6 +108,11 @@ tests:
           content:
             mountPath: /data/confmap
             name: RELEASE-NAME-kubedeploy-kubedeploy-configmap
+      - isSubset:
+          path: spec.template.spec.containers[1].volumeMounts[1]
+          content:
+            mountPath: /data/confmap/kubedeploy2
+            name: RELEASE-NAME-kubedeploy-kubedeploy2-configmap
 
   - it: test additionalContainers custom values on deployment
     template: deployment.yaml
@@ -235,18 +246,24 @@ tests:
            name: "value"
       securityContext:
         fsGroup: 2000
-      configMaps:
+      - configMaps:
         - name: kubedeploy-configmap
-          mount: True
+          mount: true
           mountPath: /data/confmap
           data:
             kubedeploy: |+
               configmap values
         - name: kubedeploy2-configmap
-          mount: False
+          mount: true
+          mountPath: /data/confmap/kubedeploy2
+          subPath: kubedeploy2
+          data:
+            kubedeploy2: |+
+              configmap values
+        - name: kubedeploy3-configmap
           data:
             config: |+
-              config2
+              config3
     asserts:
       - isSubset:
           path: spec.template.spec.containers[1].securityContext
@@ -267,6 +284,11 @@ tests:
           content:
             mountPath: /data/confmap
             name: RELEASE-NAME-kubedeploy-kubedeploy-configmap
+      - isSubset:
+          path: spec.template.spec.containers[1].volumeMounts[1]
+          content:
+            mountPath: /data/confmap/kubedeploy2
+            name: RELEASE-NAME-kubedeploy-kubedeploy2-configmap
 
   - it: test additionalContainers custom values on statefulset
     template: statefulset.yaml
@@ -400,18 +422,24 @@ tests:
            name: "value"
       securityContext:
         fsGroup: 2000
-      configMaps:
+      - configMaps:
         - name: kubedeploy-configmap
-          mount: True
+          mount: true
           mountPath: /data/confmap
           data:
             kubedeploy: |+
               configmap values
         - name: kubedeploy2-configmap
-          mount: False
+          mount: true
+          mountPath: /data/confmap/kubedeploy2
+          subPath: kubedeploy2
+          data:
+            kubedeploy2: |+
+              configmap values
+        - name: kubedeploy3-configmap
           data:
             config: |+
-              config2
+              config3
     asserts:
       - isSubset:
           path: spec.template.spec.containers[1].securityContext
@@ -432,6 +460,11 @@ tests:
           content:
             mountPath: /data/confmap
             name: RELEASE-NAME-kubedeploy-kubedeploy-configmap
+      - isSubset:
+          path: spec.template.spec.containers[1].volumeMounts[1]
+          content:
+            mountPath: /data/confmap/kubedeploy2
+            name: RELEASE-NAME-kubedeploy-kubedeploy2-configmap
 
   - it: test additionalContainers custom values on job
     template: job.yaml
@@ -565,18 +598,24 @@ tests:
            name: "value"
       securityContext:
         fsGroup: 2000
-      configMaps:
+      - configMaps:
         - name: kubedeploy-configmap
-          mount: True
+          mount: true
           mountPath: /data/confmap
           data:
             kubedeploy: |+
               configmap values
         - name: kubedeploy2-configmap
-          mount: False
+          mount: true
+          mountPath: /data/confmap/kubedeploy2
+          subPath: kubedeploy2
+          data:
+            kubedeploy2: |+
+              configmap values
+        - name: kubedeploy3-configmap
           data:
             config: |+
-              config2
+              config3
     asserts:
       - isSubset:
           path: spec.jobTemplate.spec.template.spec.containers[1].securityContext
@@ -597,6 +636,11 @@ tests:
           content:
             mountPath: /data/confmap
             name: RELEASE-NAME-kubedeploy-kubedeploy-configmap
+      - isSubset:
+          path: spec.template.spec.containers[1].volumeMounts[1]
+          content:
+            mountPath: /data/confmap/kubedeploy2
+            name: RELEASE-NAME-kubedeploy-kubedeploy2-configmap
 
   - it: test additionalContainers custom values on cronjob
     template: cronjob.yaml

--- a/kubedeploy/tests/configMaps_test.yaml
+++ b/kubedeploy/tests/configMaps_test.yaml
@@ -111,6 +111,46 @@ tests:
             mountPath: /data/confmap
             name: RELEASE-NAME-kubedeploy-configmap-name
 
+  - it: test single-file configmaps mounts on deployments
+    template: deployment.yaml
+    set:
+      deploymentMode: Deployment
+      configMaps:
+        - name: configmap-name
+          mount: True
+          mountPath: /data/confmap/kubedeploy
+          subPath: kubedeploy
+          data:
+            kubedeploy: |
+              configmap values
+
+        - name: configmap-name2
+          data:
+            config: |
+              config2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
+      - isSubset:
+          path: spec.template.spec.volumes[0]
+          content:
+            name: RELEASE-NAME-kubedeploy-configmap-name
+            configMap:
+              name: RELEASE-NAME-kubedeploy-configmap-name
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 1
+      - isSubset:
+          path: spec.template.spec.containers[0].volumeMounts[0]
+          content:
+            mountPath: /data/confmap/kubedeploy
+            name: RELEASE-NAME-kubedeploy-configmap-name
+
   - it: test configmaps mounts on statefulsets with persistence
     template: statefulset.yaml
     set:

--- a/kubedeploy/values.yaml
+++ b/kubedeploy/values.yaml
@@ -159,10 +159,18 @@ configMaps: []
   #       configmap values
   #
   # - name: kubedeploy2-configmap
+  #   mount: True
+  #   mountPath: /data/confmap/kubedeploy2 # Define single-file mount path for this configmap
+  #   subPath: kubedeploy2 # Define a configmap data key to mount to a single-file mount path
+  #   data:
+  #     kubedeploy2: |+
+  #       configmap values
+  #
+  # - name: kubedeploy3-configmap
   #   mount: False
   #   data:
   #     config: |+
-  #       config2
+  #       config3
 
 
 # -- Redeploy Deployments and Statefulsets if deployed ConfigMaps content change.


### PR DESCRIPTION
Resolves the issue described in #38.

Some additional tests should probably be added/modified before merging (for example, checking if the correct configmap data key/value pair got mounted).